### PR TITLE
Add method to build apns http client from certificate resource

### DIFF
--- a/src/main/scala/com/malliina/push/TLSUtils.scala
+++ b/src/main/scala/com/malliina/push/TLSUtils.scala
@@ -1,7 +1,6 @@
 package com.malliina.push
 
-import java.io.FileInputStream
-import java.nio.file.Path
+import java.io.InputStream
 import java.security.KeyStore
 import javax.net.ssl.{KeyManagerFactory, SSLContext}
 
@@ -10,12 +9,13 @@ import com.malliina.util.Util
 import scala.util.Try
 
 object TLSUtils {
-  def loadContext(file: Path, keyStorePass: String, storeType: String = "JKS"): Try[SSLContext] =
-    keyStoreFromFile(file, keyStorePass, storeType).map(ks => buildSSLContext(ks, keyStorePass))
 
-  def keyStoreFromFile(file: Path, keyStorePass: String, storeType: String = "JKS"): Try[KeyStore] = Try {
+  def loadContext(resource: InputStream, keyStorePass: String, storeType: String = "JKS"): Try[SSLContext] =
+    keyStoreFromResource(resource, keyStorePass, storeType).map(ks => buildSSLContext(ks, keyStorePass))
+
+  def keyStoreFromResource(resource: InputStream, keyStorePass: String, storeType: String): Try[KeyStore] = Try {
     val ks = KeyStore.getInstance(storeType)
-    Util.using(new FileInputStream(file.toFile)) { keyStream =>
+    Util.using(resource) { keyStream =>
       ks.load(keyStream, keyStorePass.toCharArray)
       ks
     }

--- a/src/main/scala/com/malliina/push/apns/APNSHttpClient.scala
+++ b/src/main/scala/com/malliina/push/apns/APNSHttpClient.scala
@@ -1,5 +1,6 @@
 package com.malliina.push.apns
 
+import java.io.{FileInputStream, InputStream}
 import java.nio.file.Path
 import java.security.KeyStore
 import javax.net.ssl.SSLSocketFactory
@@ -93,6 +94,9 @@ object APNSHttpClient {
     apply(TLSUtils.buildSSLContext(keyStore, keyStorePass).getSocketFactory, isSandbox)
 
   def fromCert(cert: Path, keyStorePass: String, keyStoreType: String, isSandbox: Boolean): Try[APNSHttpClient] =
-    TLSUtils.loadContext(cert, keyStorePass, keyStoreType)
+    fromCert(new FileInputStream(cert.toFile), keyStorePass, keyStoreType, isSandbox)
+
+  def fromCert(certResource: InputStream, keyStorePass: String, keyStoreType: String, isSandbox: Boolean): Try[APNSHttpClient] =
+    TLSUtils.loadContext(certResource, keyStorePass, keyStoreType)
       .map(ctx => new APNSCertClient(ctx.getSocketFactory, isSandbox))
 }

--- a/src/test/scala/tests/APNS2.scala
+++ b/src/test/scala/tests/APNS2.scala
@@ -1,5 +1,6 @@
 package tests
 
+import java.io.FileInputStream
 import java.nio.file.Paths
 import java.security.KeyStore
 
@@ -70,7 +71,7 @@ class APNS2 extends BaseSuite {
 
   def certContext(creds: APNSCred) = {
     val pass = creds.pass
-    TLSUtils.keyStoreFromFile(creds.file, pass, "PKCS12")
+    TLSUtils.keyStoreFromResource(new FileInputStream(creds.file.toFile), pass, "PKCS12")
       .map(ks => TLSUtils.buildSSLContext(ks, pass))
       .get
   }

--- a/src/test/scala/tests/APNSTests.scala
+++ b/src/test/scala/tests/APNSTests.scala
@@ -1,5 +1,6 @@
 package tests
 
+import java.io.FileInputStream
 import java.nio.file.{Path, Paths}
 
 import com.malliina.file.{FileUtilities, StorageFile}
@@ -34,7 +35,7 @@ class APNSTests extends BaseSuite {
 
   ignore("send notification with body, if enabled") {
     val creds = APNSHttpConf.load
-    val ks = TLSUtils.keyStoreFromFile(creds.file, creds.pass, "PKCS12").get
+    val ks = TLSUtils.keyStoreFromResource(new FileInputStream(creds.file.toFile), creds.pass, "PKCS12").get
     val client = new APNSClient(ks, creds.pass, isSandbox = true)
     val payload = AlertPayload(
       "this is a body",
@@ -49,7 +50,7 @@ class APNSTests extends BaseSuite {
 
   ignore("send pimp notification") {
     val creds = APNSHttpConf.load
-    val ks = TLSUtils.keyStoreFromFile(creds.file, creds.pass, "PKCS12").get
+    val ks = TLSUtils.keyStoreFromResource(new FileInputStream(creds.file.toFile), creds.pass, "PKCS12").get
     val client = new APNSClient(ks, creds.pass, isSandbox = true)
     val message = APNSMessage.badged("I <3 U!", 3)
     val fut = client.push(creds.token, message)
@@ -58,7 +59,7 @@ class APNSTests extends BaseSuite {
 
   ignore("send background notification, if enabled") {
     val creds = APNSHttpConf.load
-    val ks = TLSUtils.keyStoreFromFile(creds.file, creds.pass, "PKCS12").get
+    val ks = TLSUtils.keyStoreFromResource(new FileInputStream(creds.file.toFile), creds.pass, "PKCS12").get
     val client = new APNSClient(ks, creds.pass, isSandbox = true)
     val message = APNSMessage.background(badge = 16)
     await(client.push(creds.token, message))


### PR DESCRIPTION
Makes it easier to use when using the client with a certificate from a resource path, for instance embedded inside a jar file.