### PR TITLE
Add GCMNotification

### DIFF
--- a/src/main/scala/com/malliina/push/gcm/gcmModels.scala
+++ b/src/main/scala/com/malliina/push/gcm/gcmModels.scala
@@ -69,7 +69,16 @@ case class GCMMessage(
   dryRun: Option[Boolean] = None
 ) {
   def toLetter(ids: Seq[GCMToken]) =
-    GCMLetter(ids, data, notification, expiresAfter, collapseKey, delayWhileIdle, restrictedPackageName, dryRun)
+    GCMLetter(
+      ids,
+      data,
+      notification,
+      expiresAfter,
+      collapseKey,
+      delayWhileIdle,
+      restrictedPackageName,
+      dryRun
+    )
 }
 
 object GCMMessage {

--- a/src/main/scala/com/malliina/push/gcm/gcmModels.scala
+++ b/src/main/scala/com/malliina/push/gcm/gcmModels.scala
@@ -24,6 +24,25 @@ object GCMResponse {
   implicit val json = Json.reads[GCMResponse]
 }
 
+case class GCMNotification(
+  title: Option[String],
+  body: Option[String],
+  subtitle: Option[String],
+  sound: Option[String],
+  badge: Option[String],
+  icon: Option[String],
+  click_action: Option[String],
+  body_loc_key: Option[String],
+  title_loc_key: Option[String],
+  android_channel_id: Option[String],
+  tag: Option[String],
+  color: Option[String]
+)
+
+object GCMNotification {
+  implicit val json = Json.format[GCMNotification]
+}
+
 case class GCMLetter(
   registration_ids: Seq[GCMToken],
   data: Map[String, String],
@@ -58,23 +77,4 @@ object GCMMessage {
   implicit val json = Json.format[GCMMessage]
 
   type FCMMessage = GCMMessage
-}
-
-case class GCMNotification(
-  title: Option[String],
-  body: Option[String],
-  subtitle: Option[String],
-  sound: Option[String],
-  badge: Option[String],
-  icon: Option[String],
-  click_action: Option[String],
-  body_loc_key: Option[String],
-  title_loc_key: Option[String],
-  android_channel_id: Option[String],
-  tag: Option[String],
-  color: Option[String]
-)
-
-object GCMNotification {
-  implicit val json = Json.format[GCMNotification]
 }

--- a/src/main/scala/com/malliina/push/gcm/gcmModels.scala
+++ b/src/main/scala/com/malliina/push/gcm/gcmModels.scala
@@ -27,6 +27,7 @@ object GCMResponse {
 case class GCMLetter(
   registration_ids: Seq[GCMToken],
   data: Map[String, String],
+  notification: Option[GCMNotification] = None,
   time_to_live: Option[Duration] = None,
   collapse_key: Option[String] = None,
   delay_while_idle: Option[Boolean] = None,
@@ -41,6 +42,7 @@ object GCMLetter {
 
 case class GCMMessage(
   data: Map[String, String],
+  notification: Option[GCMNotification] = None,
   expiresAfter: Option[Duration] = None,
   collapseKey: Option[String] = None,
   delayWhileIdle: Option[Boolean] = None,
@@ -48,7 +50,7 @@ case class GCMMessage(
   dryRun: Option[Boolean] = None
 ) {
   def toLetter(ids: Seq[GCMToken]) =
-    GCMLetter(ids, data, expiresAfter, collapseKey, delayWhileIdle, restrictedPackageName, dryRun)
+    GCMLetter(ids, data, notification, expiresAfter, collapseKey, delayWhileIdle, restrictedPackageName, dryRun)
 }
 
 object GCMMessage {
@@ -56,4 +58,23 @@ object GCMMessage {
   implicit val json = Json.format[GCMMessage]
 
   type FCMMessage = GCMMessage
+}
+
+case class GCMNotification(
+  title: Option[String],
+  body: Option[String],
+  subtitle: Option[String],
+  sound: Option[String],
+  badge: Option[String],
+  icon: Option[String],
+  click_action: Option[String],
+  body_loc_key: Option[String],
+  title_loc_key: Option[String],
+  android_channel_id: Option[String],
+  tag: Option[String],
+  color: Option[String]
+)
+
+object GCMNotification {
+  implicit val json = Json.format[GCMNotification]
 }


### PR DESCRIPTION
Adds support for the notification key in GCMMessage.

See: https://firebase.google.com/docs/cloud-messaging/http-server-ref#downstream-http-messages-json