### PR TITLE
replaces apns utilities usage in non-deprecated code

### DIFF
--- a/core/src/main/scala/com/malliina/push/apns/apnsModels.scala
+++ b/core/src/main/scala/com/malliina/push/apns/apnsModels.scala
@@ -2,7 +2,6 @@ package com.malliina.push.apns
 
 import com.malliina.push.{SimpleCompanion, Token, TokenCompanion}
 import com.malliina.values.{ErrorMessage, StringEnumCompanion, ValidatingCompanion}
-import com.notnoop.apns.internal.Utilities
 import io.circe._
 import io.circe.generic.semiauto._
 
@@ -76,7 +75,11 @@ case class APNSToken(token: String) extends AnyVal with Token
 
 object APNSToken extends TokenCompanion[APNSToken] {
   override def isValid(token: String): Boolean =
-    Try(Utilities.decodeHex(token)).isSuccess
+    Try(decodeHex(token)).isSuccess
+
+  private def decodeHex(str: String): Array[Byte] = {
+    str.sliding(2, 2).toArray.map(h => Integer.parseInt(h, 16).toByte)
+  }
 }
 
 case class InactiveDevice(deviceHexID: String, asOf: Long)

--- a/core/src/test/scala/tests/APNSTests.scala
+++ b/core/src/test/scala/tests/APNSTests.scala
@@ -5,7 +5,6 @@ import java.nio.file.{Path, Paths}
 import com.malliina.push.apns._
 import com.malliina.push.{ConfHelper, Execution, PushUtils, TLSUtils}
 import com.malliina.values.ErrorMessage
-import com.notnoop.apns.internal.Utilities
 import scala.concurrent.ExecutionContext
 
 class APNSTests extends BaseSuite {
@@ -16,8 +15,8 @@ class APNSTests extends BaseSuite {
   test("token validation") {
     val tokenOpt = APNSToken.build(rawDeviceID)
     assert(tokenOpt.isRight)
-    intercept[RuntimeException](Utilities.decodeHex("deviceToken"))
-    val invalidToken = APNSToken.build("deviceToken")
+    val invalidDeviceToken = "deviceToken"
+    val invalidToken = APNSToken.build(invalidDeviceToken)
     assert(invalidToken.isLeft)
   }
 


### PR DESCRIPTION
apns has very outdated dependencies that trigger security vulnerability alerts.

Preferably `APNSClient` should be removed with that dependency, with this at least one can exclude the transitive apns dependency when not needed.